### PR TITLE
Configura API externa com nome de jogador (#77)

### DIFF
--- a/backend/grupos-partidas-apis/src/main/java/com/gameprofile/grupospartidasapis/configurations/RestTemplateConfig.java
+++ b/backend/grupos-partidas-apis/src/main/java/com/gameprofile/grupospartidasapis/configurations/RestTemplateConfig.java
@@ -1,0 +1,12 @@
+package com.gameprofile.grupospartidasapis.configurations;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/backend/grupos-partidas-apis/src/main/java/com/gameprofile/grupospartidasapis/controllers/JogadorController.java
+++ b/backend/grupos-partidas-apis/src/main/java/com/gameprofile/grupospartidasapis/controllers/JogadorController.java
@@ -6,14 +6,22 @@ import org.hibernate.ObjectNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.Collections;
 import java.util.List;
+
 @RestController
 @RequestMapping(value = "/jogadores")
+
 public class JogadorController {
-        @Autowired
         private JogadorRepository repository;
+
+        private RestTemplate restTemplate;
+        public JogadorController(JogadorRepository repository, RestTemplate restTemplate){
+            this.repository=repository;
+            this.restTemplate=restTemplate;
+        }
 
         @GetMapping
         public List<Jogador> findAll() {
@@ -32,5 +40,15 @@ public class JogadorController {
         public ResponseEntity<Jogador> salvar (@RequestBody Jogador jogador){
             return ResponseEntity.ok(repository.save(jogador));
         }
+        
+        
+        @GetMapping(value = "/lol/summoner/v4/summoners/by-name/{summonerName}")
+        public ResponseEntity<?> buscarJogadorPorNome(@PathVariable String summonerName) {
+            String apiKey="RGAPI-93297058-3a2f-4fc2-a962-c2542408f49b";
+            String apiUrl = "https://br1.api.riotgames.com/lol/summoner/v4/summoners/by-name/" + summonerName + "?api_key=" + apiKey;
+            ResponseEntity<?> response = restTemplate.getForEntity(apiUrl, Object.class);
+            return response;
 
+
+}
 }

--- a/backend/grupos-partidas-apis/src/main/resources/application.properties
+++ b/backend/grupos-partidas-apis/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Chave de API do League of Legends
+riot.api.key=RGAPI-93297058-3a2f-4fc2-a962-c2542408f49b
+
 ##POSTGRESQL
 spring.jpa.database=POSTGRESQL
 spring.datasource.platform=postgres


### PR DESCRIPTION
#77 - Adiciona funcionalidade de busca de jogador por nome utilizando a API externa do League of Legends. Foram realizadas modificações no controlador JogadorController, incluindo um novo endpoint que recebe o nome do jogador e utiliza o RestTemplate para fazer uma consulta à API externa para incluir a biblioteca RestTemplate. Não foram realizadas modificações nos demais arquivos do projeto, já que a funcionalidade é simples e no momento não envolve regras de negócio complexas.